### PR TITLE
Made slack href work

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             </div>
           </div>
           <a href="https://github.com/iarobinson/learn-to-be-a-useful-programmer/issues/1" class="button button-primary">Become a Collaborator</a>
-          <a href="#https://learntobeause-d322305.slack.com/messages/CG7PQCNUQ/" class="button button-primary">Our Slack Group</a>
+          <a href="https://learntobeause-d322305.slack.com/messages/CG7PQCNUQ/" class="button button-primary">Our Slack Group</a>
       </div>
 
 


### PR DESCRIPTION
Href link for Slack didn't take you immediately to the page. Removed the # so it will allow an immediate transition.